### PR TITLE
fixed unit count not decreasing on course deletion

### DIFF
--- a/zotcourse/static/js/zotcourse.js
+++ b/zotcourse/static/js/zotcourse.js
@@ -1812,9 +1812,11 @@ $(document).ready(function () {
             $(".delete-event").click(function () {
                 self.popover("dispose");
                 $("#cal").fullCalendar("removeEvents", event._id);
-                datatable.row(`#${event.groupId}`).deselect();
-                if (event.units && parseInt($("#unitCounter").text()) - parseInt(event.units) >= 0) {
-                    $("#unitCounter").text(parseInt($("#unitCounter").text()) - parseInt(event.units));
+                let row = datatable.row(`#${event.groupId}`);
+                if (row.data()) {
+                  row.deselect();
+                } else if (event.course.unit && parseInt($("#unitCounter").text()) - parseInt(event.course.unit) >= 0) {
+                    $("#unitCounter").text(parseInt($("#unitCounter").text()) - parseInt(event.course.unit));
                 }
             });
         },


### PR DESCRIPTION
fixed issue where deleting a course that is not on the listing datatable would not decrement `unitCounter`
you probably need to update `zotcourse.min.js` as well